### PR TITLE
Fix: Handle URL reserved characters in user credential

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -71,7 +72,7 @@ func AuthUB(username, password string) (*StudentDetails, error) {
 	execution := getBetween("execution=", "&amp", fullURL)
 	tabID := strings.Split(fullURL, "tab_id=")[1]
 
-	data := strings.NewReader(fmt.Sprintf("username=%s&password=%s&credentialId=%s", username, password, ""))
+	data := strings.NewReader(fmt.Sprintf("username=%s&password=%s&credentialId=%s", url.QueryEscape(username), url.QueryEscape(password), ""))
 	req, err = http.NewRequest("POST", fmt.Sprintf("https://iam.ub.ac.id/auth/realms/ub/login-actions/authenticate?session_code=%s&execution=%s&client_id=brone.ub.ac.id&tab_id=%s", sessionCode, execution, tabID), data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create POST request: %v", err)


### PR DESCRIPTION
Hi, @ahmdyaasiin .

I found a bug in this library. When the user's credential has URL reserved characters, the function always returns an "Invalid username or password" error. In this pull request, I fix it by query escaping the credential.

Best regards,
I Putu Natha Kusuma